### PR TITLE
Use `flycheck-define-command-checker` to handle vale process

### DIFF
--- a/flycheck-vale.el
+++ b/flycheck-vale.el
@@ -66,18 +66,18 @@
   "Parse the full JSON output of vale, OUTPUT, into a sequence of flycheck error structs."
   (let* ((issues (cdar (json-read-from-string output)))
 		 (filename (buffer-file-name buffer)))
-	(cl-loop
-	 for issue across issues collect
-	 (let-alist issue
-	   (flycheck-error-new
-		:buffer buffer
-		:filename filename
-		:checker checker
-		:line .Line
-		:column (elt .Span 0)
-		:message .Message
-		:level (assoc-default .Severity flycheck-vale--level-map 'string-equal 'error)
-		:id .Check)))))
+	(mapcar (lambda (issue)
+		 (let-alist issue
+		   (flycheck-error-new
+			:buffer buffer
+			:filename filename
+			:checker checker
+			:line .Line
+			:column (elt .Span 0)
+			:message .Message
+			:level (assoc-default .Severity flycheck-vale--level-map 'string-equal 'error)
+			:id .Check)))
+	   issues)))
 
 (flycheck-def-executable-var vale "vale")
 


### PR DESCRIPTION
As per the discussion in #6.

I also took the liberty of cleaning up the code a little bit more in `flycheck-vale--output-to-errors`.

I also made the `:id` of the flycheck errors be the `Check` key of the vale errors. This way you would be able to decide which specific checkers should be disabled. 
