### PR TITLE
Vale suggestions (shown as "info")

### DIFF
--- a/flycheck-vale.el
+++ b/flycheck-vale.el
@@ -70,7 +70,8 @@
 
 (defconst flycheck-vale--level-map
   '(("error" . error)
-    ("warning" . warning)))
+    ("warning" . warning)
+    ("suggestion" . info)))
 
 (defun flycheck-vale--issue-to-error (issue)
   "Parse a single vale issue, ISSUE, into a flycheck error struct.


### PR DESCRIPTION
Removed error when minimum level in vale is "suggestion". Fixes #12 